### PR TITLE
Feat/h2db

### DIFF
--- a/jaetech/build.gradle
+++ b/jaetech/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/jaetech/docker/h2compose/compose.yaml
+++ b/jaetech/docker/h2compose/compose.yaml
@@ -1,0 +1,15 @@
+version: "3.8"
+services:
+  h2:
+    image: oscarfonts/h2
+    container_name: h2-db
+    restart: always
+    ports:
+      - "8082:81"   # 웹 콘솔 포트
+      - "1521:1521"   # TCP 포트
+    environment:
+      H2_OPTIONS: "-tcp -tcpAllowOthers -ifNotExists"
+    volumes:
+      - h2-data:/opt/h2-data
+volumes:
+  h2-data:

--- a/test.md
+++ b/test.md
@@ -1,1 +1,0 @@
-test template test apply


### PR DESCRIPTION
## 🛠 Describe your changes
로컬 h2 데이터베이스를 도커 컴포즈로 컨테이너를 띄워서 데이터를 유지시킬 수 있도록 `docker-compose` 파일을 생성했습니다.

## 🔍 변경 사항
- [x] 코드 수정
- [ ] 문서 업데이트
- [ ] 테스트 추가


## Issue ticket number and link
close #6 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Did you pass the test code?
- [ ] Did you check the location of the branch to merge?

## 🚀 추가 정보
로컬에 도커가 설치한 후, 도커 컴포즈 파일이 존재하는 디렉터리로 이동한 다음 cli 를 통해 실행시킵니다.

**명령어**
```cmd
# 컨테이너를 실행시킵니다.
docker-compose up -d

# 컨테이너를 내립니다.
docker-compose down

# 컨테이너가 정상적으로 실행되고 있는지 확인
docker-compose ps
``` 